### PR TITLE
Feature/parent documents

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -32,6 +32,9 @@ export async function POST(req: NextRequest) {
 			case "partner":
 				staleRoutes.push("/", "/articles/[slug]");
 				break;
+			case "documents":
+				staleRoutes.push("/resources", "/resources/[slug]");
+				break;
 			default:
 				break;
 		}

--- a/app/resources/[slug]/page.tsx
+++ b/app/resources/[slug]/page.tsx
@@ -24,15 +24,27 @@ export default async function DocumentPage({
 				"flex flex-col flex-wrap gap-6 w-full h-full lg:max-w-7xl p-6 lg:my-44 my-20"
 			}
 		>
-			<Link
-				href="/resources"
-				className={
-					"flex flex-row items-center text-primary-main underline hover:no-underline -mt-20 gap-1 mb-14 w-fit"
-				}
-			>
-				<BackIcon />
-				<Typography className={"text-base"}> Back to resources </Typography>
-			</Link>
+			{document.parentSlug ? (
+				<Link
+					href={`/resources/${document.parentSlug.current}`}
+					className={
+						"flex flex-row items-center text-primary-main underline hover:no-underline -mt-20 gap-1 mb-14 w-fit"
+					}
+				>
+					<BackIcon />
+					<Typography className={"text-base"}>Back to {`"${document.parentTitle}"`}</Typography>
+				</Link>
+			) : (
+				<Link
+					href="/resources"
+					className={
+						"flex flex-row items-center text-primary-main underline hover:no-underline -mt-20 gap-1 mb-14 w-fit"
+					}
+				>
+					<BackIcon />
+					<Typography className={"text-base"}>Back to resources</Typography>
+				</Link>
+			)}
 			{document.body !== null && document.body !== undefined ? (
 				<PortableTextStyled content={document.body} />
 			) : (
@@ -58,5 +70,5 @@ export default async function DocumentPage({
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
 	const data = await fetchDocuments();
-	return data.map(({ slug }) => ({ slug }));
+	return data.map(({ slug }) => ({ slug: slug.current }));
 }

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,10 +1,10 @@
 import { Box, Typography } from "@mui/material";
 import { ResourcesLogo } from "@/app/icons/ResourcesLogo";
 import ResourceCard from "@/app/components/ResourceCard";
-import { fetchDocuments } from "@/sanity/api";
+import { fetchRootDocuments } from "@/sanity/api";
 
 const Home = async () => {
-	const documents = await fetchDocuments();
+	const documents = await fetchRootDocuments();
 	return (
 		<Box className={"w-full"}>
 			<Box className={"flex justify-center bg-secondary-90"}>
@@ -35,7 +35,7 @@ const Home = async () => {
 							key={document._id}
 							externalLink={false}
 							text={document.title}
-							href={`/resources/${document.slug}`}
+							href={`/resources/${document.slug.current}`}
 						/>
 					)}
 					<ResourceCard


### PR DESCRIPTION
* Added 'Go back to "<PARENT DOCUMENT TITLE"'-button on sub-documents
* Only show root-documents in `/resources`
* Revalidate pages when documents are updated on Sanity using ISR